### PR TITLE
fix: only generate mock data in development

### DIFF
--- a/AttendanceSystem.Api/Program.cs
+++ b/AttendanceSystem.Api/Program.cs
@@ -39,13 +39,13 @@ using (var scope = host.Services.CreateScope())
     var context = scope.ServiceProvider.GetRequiredService<CoursesContext>();
 
     var mockDataGenerator = scope.ServiceProvider.GetRequiredService<MockDataGenerator>();
-    await mockDataGenerator.GenerateMockData();
 
     if (builder.Environment.IsDevelopment())
     {
         // If we are in development, start with a fresh database on every launch
         context.Database.EnsureDeleted();
         context.Database.EnsureCreated();
+        await mockDataGenerator.GenerateMockData();
     }
     else
     {


### PR DESCRIPTION
This pull request includes a change to the `AttendanceSystem.Api/Program.cs` file to modify the behavior of the mock data generation during application startup. The most important change is the relocation of the `GenerateMockData` method call to ensure mock data is only generated in the development environment.

Changes to mock data generation:

* [`AttendanceSystem.Api/Program.cs`](diffhunk://#diff-c0849eea31e1ad68388cb71ec7ccdf7d24c6eb20c7ccb5feaee0e250bb3987a7L42-R48): Moved the `GenerateMockData` method call inside the development environment check to ensure mock data is generated only in development.