### PR TITLE
fix: update Swagger endpoints to allow anonymous access

### DIFF
--- a/AttendanceSystem.Api/Controllers/SwaggerController.cs
+++ b/AttendanceSystem.Api/Controllers/SwaggerController.cs
@@ -21,7 +21,7 @@ public class SwaggerController(ILogger<SwaggerController> logger, ISwashBuckleCl
     [SwaggerIgnore]
     [Function("SwaggerJson")]
     public async Task<HttpResponseData> SwaggerJson(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "swagger/json")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/json")]
         HttpRequestData  req)
     {
         return await swashBuckleClient.CreateSwaggerJsonDocumentResponse(req);
@@ -30,7 +30,7 @@ public class SwaggerController(ILogger<SwaggerController> logger, ISwashBuckleCl
     [SwaggerIgnore]
     [Function("SwaggerUi")]
     public async Task<HttpResponseData> SwaggerUi(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "swagger/ui")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/ui")]
         HttpRequestData req)
     {
         return await swashBuckleClient.CreateSwaggerUIResponse(req, "swagger/json");
@@ -46,7 +46,7 @@ public class SwaggerController(ILogger<SwaggerController> logger, ISwashBuckleCl
     [SwaggerIgnore]
     [Function("SwaggerOAuth2Redirect")]
     public async Task<HttpResponseData> SwaggerOAuth2Redirect(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "swagger/oauth2-redirect")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "swagger/oauth2-redirect")]
         HttpRequestData req)
     {
         return await swashBuckleClient.CreateSwaggerOAuth2RedirectResponse(req);


### PR DESCRIPTION
Changed the authorization level of Swagger-related endpoints from Function to Anonymous. This enables access to Swagger UI and related APIs without authentication, improving usability and accessibility for developers.