### PR TITLE
feat: add docfx

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,41 @@
+name: Build Docfx Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  actions: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-docfx:
+    name: Build Docfx
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Dotnet Setup
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.x
+      - run: dotnet tool update -g docfx
+      - run: docfx docfx.json
+      - name: Upload Docfx Documentation to Github Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: _site


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and deployment of Docfx documentation. The workflow is triggered on pushes to the main branch and includes several steps to set up the environment, build the documentation, and deploy it to GitHub Pages.

New GitHub Actions workflow:

* [`.github/workflows/build-documentation.yml`](diffhunk://#diff-3d057d43f2e0d8a5a407d2864fe5c0f250a09d347aa1831b5a0190409d1e3ef6R1-R41): Added a workflow named "Build Docfx Documentation" that sets permissions, ensures concurrency, checks out the repository, sets up .NET, updates the Docfx tool, builds the documentation, and uploads it to GitHub Pages.